### PR TITLE
add feature to handle refresh token

### DIFF
--- a/frontend/src/State/Customer/Authentication/Action.js
+++ b/frontend/src/State/Customer/Authentication/Action.js
@@ -17,7 +17,7 @@ export const registerUser = (reqData) => async (dispatch) => {
         dispatch({ type: REGISTER_SUCCESS, payload: data.token });
         console.log("register success", data);
     } catch (error) {
-        dispatch({type: REGISTER_FAILURE, payload: error});
+        dispatch({ type: REGISTER_FAILURE, payload: error });
         console.log("error", error);
 
     }
@@ -26,7 +26,7 @@ export const registerUser = (reqData) => async (dispatch) => {
 export const loginUser = (reqData) => async (dispatch) => {
     dispatch({ type: LOGIN_REQUEST });
     try {
-        const { data } = await axios.post(`${API_URL}/auth/signin`, reqData.userData);
+        const { data } = await axios.post(`${API_URL}/auth/signin`, reqData.userData, { withCredentials: true });
         if (data.token) {
             localStorage.setItem("token", data.token);
             //dispatch(getUser(data.token));
@@ -39,7 +39,7 @@ export const loginUser = (reqData) => async (dispatch) => {
         dispatch({ type: LOGIN_SUCCESS, payload: data.token });
         console.log("login success", data);
     } catch (error) {
-        dispatch({type: LOGIN_FAILURE, payload: error});
+        dispatch({ type: LOGIN_FAILURE, payload: error });
         console.log("error", error);
     }
 }
@@ -63,7 +63,7 @@ export const getUser = (jwt) => async (dispatch) => {
 
 
 
-export const addToFavourite = ({restaurantId, jwt}) => async (dispatch) => {
+export const addToFavourite = ({ restaurantId, jwt }) => async (dispatch) => {
     dispatch({ type: ADD_TO_FAVOURITE_REQUEST });
     try {
         const { data } = await api.put(`/api/restaurants/restaurant/${restaurantId}/add-favourites`, {}, {
@@ -75,7 +75,7 @@ export const addToFavourite = ({restaurantId, jwt}) => async (dispatch) => {
         console.log("add to favourite", data);
 
     } catch (error) {
-        dispatch({type: ADD_TO_FAVOURITE_FAILURE, payload: error});
+        dispatch({ type: ADD_TO_FAVOURITE_FAILURE, payload: error });
         console.log("error", error);
     }
 }
@@ -90,7 +90,7 @@ export const forgotPassword = (reqData) => async (dispatch) => {
         console.log("error", error);
     }
 }
-export const resetPassword = ({token, newPassword}) => async (dispatch) => {
+export const resetPassword = ({ token, newPassword }) => async (dispatch) => {
     dispatch({ type: RESET_PASSWORD_REQUEST });
     try {
         const { data } = await api.post(`/auth/reset-password?token=${token}&newPassword=${newPassword}`);
@@ -104,12 +104,12 @@ export const resetPassword = ({token, newPassword}) => async (dispatch) => {
 
 export const loginWithGoogle = ({ code, redirectUri, navigate }) => async (dispatch) => {
     dispatch({ type: LOGIN_GOOGLE_REQUEST });
-    
+
     try {
         const { data } = await api.post(`/auth/google/callback`, {
             code,
             redirectUri,
-        });
+        }, { withCredentials: true });
 
         if (data.token) {
             localStorage.setItem("token", data.token);
@@ -129,14 +129,16 @@ export const loginWithGoogle = ({ code, redirectUri, navigate }) => async (dispa
 
 
 export const logOut = () => async (dispatch) => {
-    dispatch({ type: LOGOUT });
     try {
+        await api.post("/auth/logout");
         localStorage.clear();
         dispatch({ type: LOGOUT });
         console.log("log out success");
 
     } catch (error) {
         console.log("error", error);
+        localStorage.clear();
+        dispatch({ type: LOGOUT });
     }
 }
 

--- a/frontend/src/State/Customer/Authentication/Reducer.js
+++ b/frontend/src/State/Customer/Authentication/Reducer.js
@@ -30,6 +30,7 @@ export const authReducer = (state = initialState, action) => {
             };
         case REGISTER_SUCCESS:
         case LOGIN_SUCCESS:
+            localStorage.setItem("token", action.payload);
             return {
                 ...state,
                 isLoading: false,
@@ -68,6 +69,7 @@ export const authReducer = (state = initialState, action) => {
                 error: null
             }
         case LOGIN_GOOGLE_SUCCESS:
+            localStorage.setItem("token", action.payload);
             return {
                 ...state,
                 isLoading: false,
@@ -94,6 +96,7 @@ export const authReducer = (state = initialState, action) => {
             };
 
         case LOGOUT:
+            localStorage.removeItem("token");
             return initialState;
         default:
             return state;

--- a/frontend/src/State/Store.js
+++ b/frontend/src/State/Store.js
@@ -16,7 +16,7 @@ import reviewReducer from './Customer/Reviews/Reducer'
 const persistConfig = {
   key: 'root',
   storage,
-  whitelist: ['auth', 'cart', 'addresses']
+  whitelist: ['cart', 'addresses']
 }
 
 const rooteReducer = combineReducers({

--- a/frontend/src/components/config/Api.js
+++ b/frontend/src/components/config/Api.js
@@ -1,10 +1,91 @@
 import axios from "axios";
+import { LOGIN_SUCCESS, LOGOUT } from "../../State/Customer/Authentication/ActionType";
+
 export const API_URL = "http://localhost:8080";
+
+let store;
+export const injectStore = (_store) => {
+    store = _store;
+}
 
 export const api = axios.create({
     baseURL: API_URL,
     headers: {
         "Content-Type": "application/json",
     },
-})
+    withCredentials: true
+});
 
+let isRefreshing = false;
+let failedQueue = [];
+
+const processQueue = (error, token = null) => {
+    failedQueue.forEach(prom => {
+        if (error) {
+            prom.reject(error);
+        } else {
+            prom.resolve(token);
+        }
+    });
+    failedQueue = [];
+};
+
+api.interceptors.request.use((config) => {
+    const token = store?.getState()?.auth?.jwt;
+    if (token && config.url.includes("/api")) {
+        config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+}, (error) => Promise.reject(error));
+
+
+// Response Interceptor
+api.interceptors.response.use(
+    (response) => response,
+    async (error) => {
+        const originalRequest = error.config;
+        console.log("📛 Interceptor error caught:", error?.response?.status, originalRequest?.url);
+        if (error.response?.status === 401 && !originalRequest._retry) {
+            if (isRefreshing) {
+                return new Promise(function (resolve, reject) {
+                    failedQueue.push({ resolve, reject });
+                }).then(token => {
+                    originalRequest.headers['Authorization'] = 'Bearer ' + token;
+                    return api(originalRequest);
+                }).catch(err => {
+                    return Promise.reject(err);
+                });
+            }
+
+            originalRequest._retry = true;
+            isRefreshing = true;
+
+            try {
+                const { data } = await api.post("/auth/refresh-token");
+                console.log('✅ Refresh response:', data);
+                const newToken = data.token;
+
+                if (!newToken) {
+                    console.error('❌ No access token in refresh response:', data);
+                    throw new Error('No access token received');
+                }
+
+                store.dispatch({ type: LOGIN_SUCCESS, payload: newToken });
+                processQueue(null, newToken);
+
+                originalRequest.headers.Authorization = `Bearer ${newToken}`;
+                return api(originalRequest);
+
+            } catch (refreshError) {
+                processQueue(refreshError, null);
+                store.dispatch({ type: LOGOUT });
+                return Promise.reject(refreshError);
+            } finally {
+                isRefreshing = false;
+            }
+        }
+        return Promise.reject(error);
+    }
+);
+
+export default api;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -6,7 +6,9 @@ import { BrowserRouter } from 'react-router-dom'
 import { Provider } from 'react-redux'
 import { store, persistor } from './State/Store.js'
 import { PersistGate } from 'redux-persist/integration/react'
+import { injectStore } from './components/config/Api.js'
 
+injectStore(store);
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>


### PR DESCRIPTION
# Merge Request: Implement Automatic Refresh Token Handling with Axios Interceptors

## Description
- Added axios request and response interceptors to automatically handle access token expiration (HTTP 401).
- On receiving a 401 error, the interceptor calls the `/auth/refresh-token` API to get a new access token.
- While the token is being refreshed, other requests that fail with 401 are queued and retried once the new token is obtained.
- If the refresh token request fails (e.g., refresh token expired), the user is automatically logged out.
- The new token is saved in Redux state and localStorage for subsequent requests.
- Prevents race conditions by using `isRefreshing` flag and a queue (`failedQueue`) to synchronize token refreshes.

## Key Changes
- Created a centralized axios instance (`api`) with configured interceptors.
- Injected Redux store to dispatch actions for updating tokens and logging out.
- Updated auth reducer and actions to handle token updates properly.

## Impact
- Improves user experience by seamlessly refreshing tokens without forcing re-login.
- Enhances app stability and security in API communications.
- Requires thorough testing of edge cases such as expired refresh tokens to ensure proper logout behavior.
